### PR TITLE
Changed default behaviour from loading an existing profile log to starting with a clean state

### DIFF
--- a/src/java/src/main/java/jcoz/client/cli/JCozCLI.java
+++ b/src/java/src/main/java/jcoz/client/cli/JCozCLI.java
@@ -65,6 +65,10 @@ public class JCozCLI {
         remoteHostOption.setRequired(false);
         ops.addOption(remoteHostOption);
 
+        Option existingProfileOption = new Option("e", "existingProfile", true, "Name of .coz file to load existing profile from");
+        remoteHostOption.setRequired(false);
+        ops.addOption(existingProfileOption);
+
         CommandLineParser parser = new DefaultParser();
         CommandLine cl = parser.parse(ops, args);
         String ppClass = cl.getOptionValue('c');
@@ -89,7 +93,8 @@ public class JCozCLI {
         if (isRemote) {
             logger.info("Connecting to remote host {}", remoteHost);
             try {
-                Profile profile = new Profile(remoteHost);
+                String existingProfileName = cl.getOptionValue("e");
+                Profile profile = new Profile(remoteHost, existingProfileName);
                 final RemoteServiceWrapper remoteService = new RemoteServiceWrapper(remoteHost);
                 TargetProcessInterface profiledClient = remoteService.attachToProcess(pid);
                 profiledClient.setProgressPoint(ppClass, ppLineNo);

--- a/src/java/src/main/java/jcoz/profile/Profile.java
+++ b/src/java/src/main/java/jcoz/profile/Profile.java
@@ -51,7 +51,7 @@ public class Profile {
     public Profile(String process, String existingProfileFilename) {
         this.process = process;
 
-        if (existingProfileFilename.isEmpty()) {
+        if (existingProfileFilename == null) {
             this.initializeProfileLogging();
         } else {
             this.loadExistingProfileLog(existingProfileFilename);


### PR DESCRIPTION
Exising default behaviour would load a `.coz` file with the name of the remote host (e.g. 212.xx.xx.xx.coz). For our use case, this behaviour is not desired. The preferred behaviour is to start all the experiments from a clean slate. To achieve the desired behaviour while ensuring the existing functionality is available, 
- An additional option to the CLI has been added (`-e` or `--existingProfile`). This allows the name of the existing `.coz` file to be passed and will be loaded by the `profile.Profile` class on initialisation.
- If the additional option is left empty (tested using `== null`), it will create a new file that uses the  remote hostname and the time stamp (e.g. `remoteHostName_20221129-1620.coz`) 

Note: This only affects the remote case as the local case does not create an instance of the `profile.Profile` class