### PR TITLE
Experiment time now has an upper limit and call frame for experiment is selected out of the unique call frames

### DIFF
--- a/src/java/src/main/java/jcoz/profile/Profile.java
+++ b/src/java/src/main/java/jcoz/profile/Profile.java
@@ -162,7 +162,7 @@ public class Profile {
      * @TODO(david): Allow the user to truncate and archive existing profiles.
      */
     private void initializeProfileLogging() {
-        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMd-Hm"));
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMdd-HHmm"));
         File profile = new File(this.process + "_" + timestamp + ".coz");
         logger.info("Creating profile {}", profile.getAbsolutePath());
         try {

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -309,10 +309,10 @@ void Profiler::runExperiment(JNIEnv *jni_env)
 }
 
 bool compareJVMPICallFrame(const JVMPI_CallFrame &lhs, const JVMPI_CallFrame &rhs) {
-  if ((void *)lhs.method_id == (void *)rhs.method_id) {
+  if (lhs.method_id == rhs.method_id) {
     return lhs.lineno < rhs.lineno;
   } else {
-    return (void *)lhs.method_id < (void *)rhs.method_id;
+    return lhs.method_id < rhs.method_id;
   }
 }
 
@@ -366,25 +366,12 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
       call_index = 0;
 
       logger->info("Profiler::runAgentThread() - Found {} call frames", call_frames.size());
-      for (int i = 0; i < call_frames.size(); i++)
-      {
-        JVMPI_CallFrame curFrame = call_frames.at(i);
-        std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
-        logger->info("Profiler::runAgentThread() - Frame {}/{}: mthID={} name={} lineNo={}", i, call_frames.size(), (void *)curFrame.method_id, methodName, curFrame.lineno);
-      }
       std::sort(call_frames.begin(), call_frames.end(), compareJVMPICallFrame);
       auto last = std::unique(call_frames.begin(), call_frames.end());
       call_frames.erase(last, call_frames.end());
       logger->info("Profiler::runAgentThread() - Found {} unique call frames", call_frames.size());
 
       std::random_shuffle(call_frames.begin(), call_frames.end());
-
-      for (int i = 0; i < call_frames.size(); i++)
-      {
-        JVMPI_CallFrame curFrame = call_frames.at(i);
-        std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
-        logger->info("Profiler::runAgentThread() - Frame {}/{}: mthID={} name={} lineNo={}", i, call_frames.size(), (void *)curFrame.method_id, methodName, curFrame.lineno);
-      }
 
       JVMPI_CallFrame exp_frame;
       jint num_entries;

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -57,6 +57,9 @@ __thread JNIEnv *Accessors::env_;
 #define MIN_EXP_TIME 5000
 #define MAX_EXP_TIME 80000
 
+#define INC_EXP_TIME_THRESHOLD 5
+#define DEC_EXP_TIME_THRESHOLD 20
+
 #define NUM_CALL_FRAMES 200
 
 typedef std::chrono::duration<int, std::milli> milliseconds_type;
@@ -284,14 +287,14 @@ void Profiler::runExperiment(JNIEnv *jni_env)
   // Maybe update the experiment length
   if (!fix_exp)
   {
-    if (current_experiment.points_hit <= 5)
+    if (current_experiment.points_hit <= INC_EXP_TIME_THRESHOLD)
     {
       experiment_time *= 2;
       if (experiment_time > MAX_EXP_TIME) {
         experiment_time = MAX_EXP_TIME;
       }
     }
-    else if ((experiment_time > MIN_EXP_TIME) && (current_experiment.points_hit >= 20))
+    else if ((experiment_time > MIN_EXP_TIME) && (current_experiment.points_hit >= DEC_EXP_TIME_THRESHOLD))
     {
       experiment_time /= 2;
     }

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -367,31 +367,9 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
       jint num_entries;
       jvmtiLineNumberEntry *entries = NULL;
 
-      // for (int i = 0; i < call_frames.size(); i++)
-      // {
-      //   exp_frame = call_frames.at(i);
-      //   jvmtiError lineNumberError = jvmti->GetLineNumberTable(exp_frame.method_id, &num_entries, &entries);
-      //   if (lineNumberError == JVMTI_ERROR_NONE)
-      //   {
-      //     // logger->info("Profiler::runAgentThread() - Selecting call frame at index {}/{} with methodID {} L{}", i, call_frames.size(), (void *)exp_frame.method_id, exp_frame.lineno);
-      //     break;
-      //   }
-      //   else
-      //   {
-      //     jvmti->Deallocate((unsigned char *)entries);
-      //   }
-      // }
-
-      logger->info("Profiler::runAgentThread() - Found {} unique call frames", unique_call_frames.size());
-      for (auto& curFrame: unique_call_frames)
+      for (int i = 0; i < call_frames.size(); i++)
       {
-        std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
-        logger->info("Profiler::runAgentThread() - mthID={} name={} lineNo={}",  (void *)curFrame.method_id, methodName, curFrame.lineno);
-      }
-
-      for (auto& cur_frame: unique_call_frames)
-      {
-        exp_frame = cur_frame;
+        exp_frame = call_frames.at(i);
         jvmtiError lineNumberError = jvmti->GetLineNumberTable(exp_frame.method_id, &num_entries, &entries);
         if (lineNumberError == JVMTI_ERROR_NONE)
         {
@@ -403,6 +381,28 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
           jvmti->Deallocate((unsigned char *)entries);
         }
       }
+
+      logger->info("Profiler::runAgentThread() - Found {} unique call frames", unique_call_frames.size());
+      for (auto& curFrame: unique_call_frames)
+      {
+        std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
+        logger->info("Profiler::runAgentThread() - mthID={} name={} lineNo={}",  (void *)curFrame.method_id, methodName, curFrame.lineno);
+      }
+
+      // for (auto& cur_frame: unique_call_frames)
+      // {
+      //   exp_frame = cur_frame;
+      //   jvmtiError lineNumberError = jvmti->GetLineNumberTable(exp_frame.method_id, &num_entries, &entries);
+      //   if (lineNumberError == JVMTI_ERROR_NONE)
+      //   {
+      //     // logger->info("Profiler::runAgentThread() - Selecting call frame at index {}/{} with methodID {} L{}", i, call_frames.size(), (void *)exp_frame.method_id, exp_frame.lineno);
+      //     break;
+      //   }
+      //   else
+      //   {
+      //     jvmti->Deallocate((unsigned char *)entries);
+      //   }
+      // }
 
       // If we don't find anything in scope, try again
       if (entries == NULL)

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -361,7 +361,7 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
 
       std::random_shuffle(call_frames.begin(), call_frames.end());
 
-      // std::set<JVMPI_CallFrame> unique_call_frames(call_frames.begin(), call_frames.end());
+      std::set<JVMPI_CallFrame> unique_call_frames(call_frames.begin(), call_frames.end());
 
       JVMPI_CallFrame exp_frame;
       jint num_entries;
@@ -382,12 +382,12 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
         }
       }
 
-      // logger->info("Profiler::runAgentThread() - Found {} unique call frames", unique_call_frames.size());
-      // for (auto& curFrame: unique_call_frames)
-      // {
-      //   std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
-      //   logger->info("Profiler::runAgentThread() - mthID={} name={} lineNo={}",  (void *)curFrame.method_id, methodName, curFrame.lineno);
-      // }
+      logger->info("Profiler::runAgentThread() - Found {} unique call frames", unique_call_frames.size());
+      for (auto& curFrame: unique_call_frames)
+      {
+        std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
+        logger->info("Profiler::runAgentThread() - mthID={} name={} lineNo={}",  (void *)curFrame.method_id, methodName, curFrame.lineno);
+      }
 
       // for (auto& cur_frame: unique_call_frames)
       // {

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -352,12 +352,38 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
       // }
 
       std::random_shuffle(call_frames.begin(), call_frames.end());
+
+      std::set<JVMPI_CallFrame> unique_call_frames(call_frames.begin(), call_frames.end());
+
       JVMPI_CallFrame exp_frame;
       jint num_entries;
       jvmtiLineNumberEntry *entries = NULL;
-      for (int i = 0; i < call_frames.size(); i++)
+
+      // for (int i = 0; i < call_frames.size(); i++)
+      // {
+      //   exp_frame = call_frames.at(i);
+      //   jvmtiError lineNumberError = jvmti->GetLineNumberTable(exp_frame.method_id, &num_entries, &entries);
+      //   if (lineNumberError == JVMTI_ERROR_NONE)
+      //   {
+      //     // logger->info("Profiler::runAgentThread() - Selecting call frame at index {}/{} with methodID {} L{}", i, call_frames.size(), (void *)exp_frame.method_id, exp_frame.lineno);
+      //     break;
+      //   }
+      //   else
+      //   {
+      //     jvmti->Deallocate((unsigned char *)entries);
+      //   }
+      // }
+
+      logger->info("Profiler::runAgentThread() - Found {} unique call frames", unique_call_frames.size());
+      for (JVMPI_CallFrame& curFrame: unique_call_frames)
       {
-        exp_frame = call_frames.at(i);
+        std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
+        logger->info("Profiler::runAgentThread() - Frame {}/{}: mthID={} name={} lineNo={}", i, call_frames.size(), (void *)curFrame.method_id, methodName, curFrame.lineno);
+      }
+
+      for (JVMPI_CallFrame& cur_frame: unique_call_frames)
+      {
+        exp_frame = cur_frame;
         jvmtiError lineNumberError = jvmti->GetLineNumberTable(exp_frame.method_id, &num_entries, &entries);
         if (lineNumberError == JVMTI_ERROR_NONE)
         {

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -55,7 +55,7 @@ __thread JNIEnv *Accessors::env_;
 #define SIGNAL_FREQ 1000000L
 // Experiment time in milliseconds
 #define MIN_EXP_TIME 5000
-#define MAX_EXP_TIME 5000
+#define MAX_EXP_TIME 80000
 
 #define NUM_CALL_FRAMES 200
 
@@ -287,6 +287,9 @@ void Profiler::runExperiment(JNIEnv *jni_env)
     if (current_experiment.points_hit <= 5)
     {
       experiment_time *= 2;
+      if (experiment_time > MAX_EXP_TIME) {
+        experiment_time = MAX_EXP_TIME;
+      }
     }
     else if ((experiment_time > MIN_EXP_TIME) && (current_experiment.points_hit >= 20))
     {
@@ -588,14 +591,14 @@ bool inline Profiler::frameInScope(JVMPI_CallFrame &curr_frame)
 
 void Profiler::addInScopeMethods(jint method_count, jmethodID *methods)
 {
-  logger->info("Adding {:d} in scope methods", method_count);
+  //logger->info("Adding {:d} in scope methods", method_count);
   while (!__sync_bool_compare_and_swap(&in_scope_lock, 0, pthread_self()))
     ;
   std::atomic_thread_fence(std::memory_order_acquire);
   for (int i = 0; i < method_count; i++)
   {
     void *method = (void *)methods[i];
-    logger->info("Adding in scope method {}\n", method);
+    //logger->info("Adding in scope method {}", method);
     in_scope_ids.insert(method);
   }
   in_scope_lock = 0;

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -375,13 +375,13 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
       // }
 
       logger->info("Profiler::runAgentThread() - Found {} unique call frames", unique_call_frames.size());
-      for (JVMPI_CallFrame& curFrame: unique_call_frames)
+      for (auto& curFrame: unique_call_frames)
       {
         std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
         logger->info("Profiler::runAgentThread() - mthID={} name={} lineNo={}",  (void *)curFrame.method_id, methodName, curFrame.lineno);
       }
 
-      for (JVMPI_CallFrame& cur_frame: unique_call_frames)
+      for (auto& cur_frame: unique_call_frames)
       {
         exp_frame = cur_frame;
         jvmtiError lineNumberError = jvmti->GetLineNumberTable(exp_frame.method_id, &num_entries, &entries);

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -360,8 +360,9 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
     {
       call_frames.push_back(static_call_frames[i]);
     }
-    if (call_frames.size() > 0)
-    {
+
+    // Gets the unique call frames
+    if (call_frames.size() > 0) {
       logger->debug("Had {} call frames. Checking for in scope call frame...", call_frames.size());
       call_index = 0;
 
@@ -370,7 +371,10 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
       auto last = std::unique(call_frames.begin(), call_frames.end());
       call_frames.erase(last, call_frames.end());
       logger->info("Profiler::runAgentThread() - Found {} unique call frames", call_frames.size());
+    }
 
+    if (call_frames.size() > 0)
+    {
       std::random_shuffle(call_frames.begin(), call_frames.end());
 
       JVMPI_CallFrame exp_frame;

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -378,7 +378,7 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
       for (JVMPI_CallFrame& curFrame: unique_call_frames)
       {
         std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
-        logger->info("Profiler::runAgentThread() - Frame {}/{}: mthID={} name={} lineNo={}", i, call_frames.size(), (void *)curFrame.method_id, methodName, curFrame.lineno);
+        logger->info("Profiler::runAgentThread() - mthID={} name={} lineNo={}",  (void *)curFrame.method_id, methodName, curFrame.lineno);
       }
 
       for (JVMPI_CallFrame& cur_frame: unique_call_frames)

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -361,7 +361,7 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
 
       std::random_shuffle(call_frames.begin(), call_frames.end());
 
-      std::set<JVMPI_CallFrame> unique_call_frames(call_frames.begin(), call_frames.end());
+      // std::set<JVMPI_CallFrame> unique_call_frames(call_frames.begin(), call_frames.end());
 
       JVMPI_CallFrame exp_frame;
       jint num_entries;
@@ -382,12 +382,12 @@ Profiler::runAgentThread(jvmtiEnv *jvmti_env, JNIEnv *jni_env, void *args)
         }
       }
 
-      logger->info("Profiler::runAgentThread() - Found {} unique call frames", unique_call_frames.size());
-      for (auto& curFrame: unique_call_frames)
-      {
-        std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
-        logger->info("Profiler::runAgentThread() - mthID={} name={} lineNo={}",  (void *)curFrame.method_id, methodName, curFrame.lineno);
-      }
+      // logger->info("Profiler::runAgentThread() - Found {} unique call frames", unique_call_frames.size());
+      // for (auto& curFrame: unique_call_frames)
+      // {
+      //   std::string methodName = std::string(getClassFromMethodIDLocation(curFrame.method_id));
+      //   logger->info("Profiler::runAgentThread() - mthID={} name={} lineNo={}",  (void *)curFrame.method_id, methodName, curFrame.lineno);
+      // }
 
       // for (auto& cur_frame: unique_call_frames)
       // {

--- a/src/native/profiler.cc
+++ b/src/native/profiler.cc
@@ -213,6 +213,14 @@ float Profiler::calculate_random_speedup()
   }
 }
 
+bool operator<(const JVMPI_CallFrame &lhs, const JVMPI_CallFrame &rhs){
+  if ((void *)lhs.method_id == (void *)rhs.method_id) {
+    return lhs.lineno < rhs.lineno;
+  } else {
+    return (void *)lhs.method_id < (void *)rhs.method_id;
+  }
+}
+
 void Profiler::runExperiment(JNIEnv *jni_env)
 {
   logger->info("Running experiment");


### PR DESCRIPTION
## Unique call frames

- _Existing implementation:_ Selects a call frame from a randomly shuffled vector of all call frames
- _Limitation of existing implementation:_ As the same call frame can occur multiple times within the vector, it introduces a bias towards selecting it, e.g. if there are 3 call frames and 2 are identical, the repetitions have a 2 in 3 chance of being selected
- _Why did this need to be addressed?_ It was observed that for our use case, the same class and line number kept getting selected
- _Solution:_ Using `std::sort()` and `std::unique()`, the `call_frames` variable would only contain unique `JVMPI_CallFrame`s
- _Could be improved:_ Using a set is likely a more efficient manner to achieve this. However, as there was constantly issues with getting that to work, this method was attempted. It worked, so it has been left at that as there is currently not a requirement to make it as efficient as possible

## Experiment time upper limit

- _Observation:_ Occasionally, rarely hit classes are repeatedly selected as the experiment call frame. This results in an exponential growth in experiment time (hits many hours for a single experiment)
- _Solution:_ Introduced a macro `MAX_EXPERIMENT_TIME` and the required logic to limit the experiment time to this value
- Note: Ideally, `MAX_EXPERIMENT_TIME` should be a multiple of `MIN_EXPERIMENT_TIME` such that the `experiment_time *=2` and `experiment_time /= 2` consistently yield the same values (e.g. if `MIN_EXPERIMENT_TIME` = 5000, then experiment time will always be 5000, 10000, 20000, etc)